### PR TITLE
fix: タブバーの高さを拡大し、時差の文字色を修正

### DIFF
--- a/__tests__/lib/colors.test.ts
+++ b/__tests__/lib/colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getTimeDiffColorClass } from "@/lib/colors";
+import { getTimeDiffColor, getTimeDiffColorClass } from "@/lib/colors";
 
 describe("getTimeDiffColorClass", () => {
   it("Given プラス時差 When 判定する Then 緑色を返す", () => {
@@ -33,5 +33,29 @@ describe("getTimeDiffColorClass", () => {
     expect(getTimeDiffColorClass(1, 30)).toBe("text-emerald-400");
     // -1:30 → 赤
     expect(getTimeDiffColorClass(-1, -30)).toBe("text-rose-400");
+  });
+});
+
+describe("getTimeDiffColor", () => {
+  it("Given プラス時差 When 判定する Then 緑色コードを返す", () => {
+    expect(getTimeDiffColor(1)).toBe("#34d399");
+    expect(getTimeDiffColor(9)).toBe("#34d399");
+  });
+
+  it("Given マイナス時差 When 判定する Then 赤色コードを返す", () => {
+    expect(getTimeDiffColor(-1)).toBe("#fb7185");
+    expect(getTimeDiffColor(-12)).toBe("#fb7185");
+  });
+
+  it("Given 時差がゼロ When 判定する Then グレーコードを返す", () => {
+    expect(getTimeDiffColor(0)).toBe("#94a3b8");
+  });
+
+  it("Given プラス分オフセット When 時間がゼロ Then 緑色コードを返す", () => {
+    expect(getTimeDiffColor(0, 30)).toBe("#34d399");
+  });
+
+  it("Given マイナス分オフセット When 時間がゼロ Then 赤色コードを返す", () => {
+    expect(getTimeDiffColor(0, -30)).toBe("#fb7185");
   });
 });

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -52,9 +52,9 @@ export default function TabLayout() {
           backgroundColor: TAB_BAR_BACKGROUND,
           borderTopColor: "#334155",
           borderTopWidth: 1,
-          paddingTop: 8,
-          paddingBottom: Platform.OS === "ios" ? 28 : 12,
-          height: Platform.OS === "ios" ? 88 : 64,
+          paddingTop: 12,
+          paddingBottom: Platform.OS === "ios" ? 32 : 20,
+          height: Platform.OS === "ios" ? 100 : 96,
         },
         tabBarLabelStyle: {
           fontSize: 11,

--- a/app/(tabs)/calculator.tsx
+++ b/app/(tabs)/calculator.tsx
@@ -6,7 +6,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { DigitalClock } from "@/components/DigitalClock";
 import { Card } from "@/components/ui/Card";
 import { useTimeDifference } from "@/hooks/use-clock";
-import { getTimeDiffColorClass } from "@/lib/colors";
+import { getTimeDiffColor } from "@/lib/colors";
 import { useCalculatorStore } from "@/store/calculator";
 
 export default function CalculatorScreen() {
@@ -94,7 +94,10 @@ export default function CalculatorScreen() {
           <Card variant="elevated" className="mt-6">
             <Text className="text-center text-secondary-300 mb-2">時差</Text>
             <Text
-              className={`text-center text-4xl font-bold ${getTimeDiffColorClass(timeDiff.hours, timeDiff.minutes)}`}
+              className="text-center text-4xl font-bold"
+              style={{
+                color: getTimeDiffColor(timeDiff.hours, timeDiff.minutes),
+              }}
             >
               {timeDiff.formatted}
             </Text>

--- a/components/CityCard.tsx
+++ b/components/CityCard.tsx
@@ -2,10 +2,29 @@ import { Ionicons } from "@expo/vector-icons";
 import { memo } from "react";
 import { Pressable, Text, View } from "react-native";
 import { useClock, useTimeDifference } from "@/hooks/use-clock";
-import { getTimeDiffColorClass } from "@/lib/colors";
+import { getTimeDiffColor } from "@/lib/colors";
 import { useSettingsStore } from "@/store/settings";
 import type { UserCity } from "@/types";
 import { Card } from "./ui/Card";
+
+interface TimeDiffTextProps {
+  hours: number;
+  minutes: number;
+  formatted: string;
+}
+
+const TimeDiffText = memo(function TimeDiffText({
+  hours,
+  minutes,
+  formatted,
+}: TimeDiffTextProps) {
+  const color = getTimeDiffColor(hours, minutes);
+  return (
+    <Text className="text-base font-medium mt-1" style={{ color }}>
+      {formatted}
+    </Text>
+  );
+});
 
 interface CityCardProps {
   city: UserCity;
@@ -65,11 +84,11 @@ export const CityCard = memo(function CityCard({
           <Text className="text-4xl font-mono font-bold text-white">
             {time}
           </Text>
-          <Text
-            className={`text-base font-medium mt-1 ${getTimeDiffColorClass(timeDiff.hours, timeDiff.minutes)}`}
-          >
-            {timeDiff.formatted}
-          </Text>
+          <TimeDiffText
+            hours={timeDiff.hours}
+            minutes={timeDiff.minutes}
+            formatted={timeDiff.formatted}
+          />
         </View>
 
         {showRemoveButton && onRemove && (

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -1,3 +1,10 @@
+// 時差表示用の色定義
+const TIME_DIFF_COLORS = {
+  positive: "#34d399", // emerald-400
+  negative: "#fb7185", // rose-400
+  neutral: "#94a3b8", // secondary-400
+} as const;
+
 /**
  * 時差の値に基づいて表示色のクラス名を返す
  * - プラス時差（進んでいる）: 緑色
@@ -12,4 +19,20 @@ export function getTimeDiffColorClass(hours: number, minutes = 0): string {
   if (totalMinutes > 0) return "text-emerald-400";
   if (totalMinutes < 0) return "text-rose-400";
   return "text-secondary-400";
+}
+
+/**
+ * 時差の値に基づいて表示色（カラーコード）を返す
+ * - プラス時差（進んでいる）: 緑色
+ * - マイナス時差（遅れている）: 赤色
+ * - 同一時間: グレー
+ *
+ * @param hours - 時差の時間部分
+ * @param minutes - 時差の分部分（デフォルト: 0）
+ */
+export function getTimeDiffColor(hours: number, minutes = 0): string {
+  const totalMinutes = hours * 60 + minutes;
+  if (totalMinutes > 0) return TIME_DIFF_COLORS.positive;
+  if (totalMinutes < 0) return TIME_DIFF_COLORS.negative;
+  return TIME_DIFF_COLORS.neutral;
 }


### PR DESCRIPTION
## 概要
- Androidでタブバーのボタンが押しづらい問題を修正
- 時差表示の文字色が黒くなる問題を修正

## 変更内容
- タブバーの高さを約1.5倍に拡大（Android: 64→96、iOS: 88→100）
- パディングも調整してタップ領域を改善
- 時差表示の色をNativeWindの動的クラス名からインラインスタイルに変更
- `getTimeDiffColor` 関数を追加（カラーコードを直接返す）

## 変更の種類
- [x] 🐛 バグ修正
- [ ] ✨ 新機能
- [ ] ♻️ リファクタリング

## テスト
- [x] テストがパス（57テスト全てパス）
- [x] TypeCheckパス
- [x] Lintパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 都市カードに削除ボタンの表示/非表示を制御するオプションを追加しました

* **改善**
  * タブバーのパディングと高さをiOS/Android両プラットフォームで調整し、レイアウトを最適化しました
  * 時間差表示の色表示ロジックを更新し、より一貫した視覚表現を実現しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->