### PR TITLE
feat: Google Play 自動提出設定 (EAS Submit)

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -41,13 +41,13 @@
         "appleTeamId": "${APPLE_TEAM_ID}"
       },
       "android": {
-        "serviceAccountKeyPath": "${GOOGLE_SERVICE_ACCOUNT_KEY_PATH}",
+        "serviceAccountKeyPath": "@secret:GOOGLE_SERVICE_ACCOUNT",
         "track": "production"
       }
     },
     "closed-testing": {
       "android": {
-        "serviceAccountKeyPath": "${GOOGLE_SERVICE_ACCOUNT_KEY_PATH}",
+        "serviceAccountKeyPath": "@secret:GOOGLE_SERVICE_ACCOUNT",
         "track": "alpha"
       }
     }


### PR DESCRIPTION
## Summary
- EAS Secrets を使用した Google Play 自動提出設定
- `serviceAccountKeyPath` を環境変数参照から `@secret:GOOGLE_SERVICE_ACCOUNT` に変更

## Changes
- `eas.json`: production と closed-testing の Android submit 設定を更新

## Test plan
- [ ] `eas submit -p android --profile closed-testing` で実際に提出をテスト

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Android デプロイメント設定のセキュリティを強化しました。本番環境およびクローズドテスト環境における認証情報の管理方式を更新。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->