### PR TITLE
fix: タブバーの高さをセーフエリアインセットで動的計算

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,7 +1,8 @@
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
 import { Tabs } from "expo-router";
-import { Platform, View } from "react-native";
+import { View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const PRIMARY_COLOR = "#0ea5e9";
 const INACTIVE_COLOR = "#64748b";
@@ -30,7 +31,13 @@ function TabBarIcon({
   );
 }
 
+const TAB_BAR_PADDING_TOP = 12;
+const TAB_BAR_CONTENT_HEIGHT = 56;
+
 export default function TabLayout() {
+  const insets = useSafeAreaInsets();
+  const paddingBottom = Math.max(insets.bottom, 20);
+
   const handleTabPress = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
   };
@@ -52,9 +59,9 @@ export default function TabLayout() {
           backgroundColor: TAB_BAR_BACKGROUND,
           borderTopColor: "#334155",
           borderTopWidth: 1,
-          paddingTop: 12,
-          paddingBottom: Platform.OS === "ios" ? 32 : 20,
-          height: Platform.OS === "ios" ? 100 : 96,
+          paddingTop: TAB_BAR_PADDING_TOP,
+          paddingBottom,
+          height: TAB_BAR_PADDING_TOP + TAB_BAR_CONTENT_HEIGHT + paddingBottom,
         },
         tabBarLabelStyle: {
           fontSize: 11,


### PR DESCRIPTION
## Summary
- `useSafeAreaInsets()` を使用してシステムナビゲーションバーの高さを動的に取得
- タブバーの `paddingBottom` と `height` をセーフエリアインセットに基づいて動的に計算
- `Platform.OS` による固定値分岐を廃止し、iOS/Android 両方で統一的に処理

## Changes
- `app/(tabs)/_layout.tsx`: `Platform` を `useSafeAreaInsets` に置換し、`paddingBottom` と `height` を動的に算出

## Test plan
- [ ] Android 3ボタンナビゲーション端末でタブバーラベルが隠れないことを確認
- [ ] Android ジェスチャーナビゲーション端末で正しく表示されることを確認
- [ ] iOS でタブバーの表示に変化がないことを確認

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)